### PR TITLE
Adding method_missing to CompositeData

### DIFF
--- a/lib/jmx4r.rb
+++ b/lib/jmx4r.rb
@@ -12,6 +12,14 @@ class String
     tr("-", "_").
     downcase
   end
+  
+  # Transform a snake_case String to a camelCase String with a lowercase initial.
+  #--
+  # Code has been taken from ActiveSupport
+  def camel_case
+    name = gsub(/\/(.?)/) { "::#{$1.upcase}" }.gsub(/(?:^|_)(.)/) { $1.upcase }
+    name[0].chr.downcase + name[1..-1]
+  end
 end
 
 module JMX

--- a/lib/open_data_helper.rb
+++ b/lib/open_data_helper.rb
@@ -27,6 +27,16 @@ JavaUtilities.extend_proxy('javax.management.openmbean.CompositeDataSupport') do
   def [](key)
     self.get key
   end
+  
+  def method_missing(name, *args)
+    key = name.to_s.camel_case
+    super unless containsKey(key)
+    get(name.to_s.camel_case)
+  end
+  
+  def respond_to?(symbol, include_private = false)
+    containsKey(symbol.to_s.camel_case) || super
+  end
 end
 
 JavaUtilities.extend_proxy('javax.management.openmbean.TabularDataSupport') do

--- a/test/tc_composite_data.rb
+++ b/test/tc_composite_data.rb
@@ -39,6 +39,25 @@ class TestCompositeData < Test::Unit::TestCase
     assert @heap.member?("used")
   end
   
+  def test_composite_data_method_missing
+    assert @heap.used
+    
+    def @heap.containsKey(key)
+      "camelCaseAttributeName" == key
+    end
+
+    def @heap.get(key)
+      return "value" if "camelCaseAttributeName" == key
+      raise("should not happen")
+    end
+    
+    assert_equal "value", @heap.camel_case_attribute_name
+    
+    assert_raises NoMethodError do
+      @heap.unknown_attribute
+    end
+  end
+  
   def test_composite_data_as_hash
     used = @heap.get "used"
     used_from_hash = @heap["used"]


### PR DESCRIPTION
Hi Jeff,

I integrated the changes to your code and added a simple test. It seems to work.
I was just surprised by the line:

JavaUtilities.extend_proxy('javax.management.openmbean.CompositeDataSupport') do

Why extend the class and not the interface ? Wouldn't it be more general ?

Best regards,
Dominique Broeglin
