### PR TITLE
Replace deprectated include_class with java_import

### DIFF
--- a/lib/jdk/jdk5.rb
+++ b/lib/jdk/jdk5.rb
@@ -2,11 +2,11 @@
 module JMX
   module JDKHelper
     module JDK5
-      include_class 'sun.jvmstat.monitor.HostIdentifier'
-      include_class 'sun.jvmstat.monitor.MonitoredHost'
-      include_class 'sun.jvmstat.monitor.MonitoredVmUtil'
-      include_class 'sun.jvmstat.monitor.VmIdentifier'
-      include_class 'sun.management.ConnectorAddressLink'
+      java_import sun.jvmstat.monitor.HostIdentifier
+      java_import sun.jvmstat.monitor.MonitoredHost
+      java_import sun.jvmstat.monitor.MonitoredVmUtil
+      java_import sun.jvmstat.monitor.VmIdentifier
+      java_import sun.management.ConnectorAddressLink
 
       class << self
 

--- a/lib/jdk/jdk6.rb
+++ b/lib/jdk/jdk6.rb
@@ -2,7 +2,7 @@
 module JMX
   module JDKHelper
     module JDK6
-      include_class 'com.sun.tools.attach.VirtualMachine'
+      java_import com.sun.tools.attach.VirtualMachine
 
       class << self
         def find_local_url(command_pattern)

--- a/lib/jdk_helper.rb
+++ b/lib/jdk_helper.rb
@@ -1,7 +1,7 @@
 
 module JMX
   module JDKHelper
-    include_class 'java.lang.System'
+    java_import java.lang.System
 
     class << self
 
@@ -29,7 +29,7 @@ module JMX
 
       def has_java_class?(name)
         begin
-          include_class name
+          java_import name
           true
         rescue
           retry if load_tools_jar

--- a/lib/jmx4r.rb
+++ b/lib/jmx4r.rb
@@ -55,13 +55,13 @@ module JMX
   end
 
   class MBean
-    include_class 'java.util.HashMap'
-    include_class 'javax.naming.Context'
-    include_class 'javax.management.Attribute'
-    include_class 'javax.management.ObjectName'
-    include_class 'javax.management.remote.JMXConnector'
-    include_class 'javax.management.remote.JMXConnectorFactory'
-    include_class 'javax.management.remote.JMXServiceURL'
+    java_import java.util.HashMap
+    java_import javax.naming.Context
+    java_import javax.management.Attribute
+    java_import javax.management.ObjectName
+    java_import javax.management.remote.JMXConnector
+    java_import javax.management.remote.JMXConnectorFactory
+    java_import javax.management.remote.JMXServiceURL
     JThread = java.lang.Thread
 
     attr_reader :object_name, :operations, :attributes, :connection


### PR DESCRIPTION
JRuby 1.7 now gives a warning message for using include_class.
This commit avoids the warnings by using "java_import" instead.
