### PR TITLE
Allow attributes to be backed by methods, not just plain attr_accessors

### DIFF
--- a/lib/dynamic_mbean.rb
+++ b/lib/dynamic_mbean.rb
@@ -181,17 +181,20 @@ module JMX
       end
     end
 
-    def self.define_jmx_getter(name, type)
+    def self.define_jmx_getter(name, type, access_proc=nil)
       define_method("jmx_get_#{name.to_s.downcase}") do
-        begin
-          #attempt conversion
+
+        value = self.send(name)
+        #attempt conversion
+        converted_value = begin
           java_type = to_java_type(type)
-          value = eval "#{java_type}.new(@#{name.to_s})"
+          # we eval just to get the class object
+          (eval "java_type").new(value)
         rescue
           #otherwise turn it into a java Object type for now.
-          value = eval "Java.ruby_to_java(@#{name.to_s})"
+          Java.ruby_to_java(value)
         end
-        attribute = javax.management.Attribute.new(name.to_s, value)
+        attribute = javax.management.Attribute.new(name.to_s, converted_value)
       end
     end
 

--- a/lib/jconsole.rb
+++ b/lib/jconsole.rb
@@ -17,11 +17,14 @@ module JConsole
   # [:pwd_file]    the path to the file containing the authentication credentials
   # [:access_file] the path to the file containing the authorization credentials
   #
-  # The file path corresponding to :pwd_file must have <b>600 permission</b> 
+  # The file path corresponding to :pwd_file must have <b>600 permission</b>
   # (<tt>chmod 600 jmxremote.password</tt>).
-  # 
-  # Both <tt>:pwd_file</tt> and <tt>:access_file+</tt> must be specified to run a secure 
+  #
+  # Both <tt>:pwd_file</tt> and <tt>:access_file+</tt> must be specified to run a secure
   # jconsole (see {JMX password & access files}[http://java.sun.com/j2se/1.5.0/docs/guide/management/agent.html#PasswordAccessFiles])
+  #
+  # Returns the process id of the jconsole process
+  #
   def JConsole.start(args={})
     port = args[:port] || 3000
     pwd_file = args[:pwd_file]

--- a/lib/jdk/jdk5.rb
+++ b/lib/jdk/jdk5.rb
@@ -26,6 +26,11 @@ module JMX
           nil
         end
 
+        def find_local_url_by_pid(pid)
+          # TODO this should be possible, right?
+          raise NotImplementedError
+        end
+
       end
 
     end

--- a/lib/jdk/jdk6.rb
+++ b/lib/jdk/jdk6.rb
@@ -15,6 +15,16 @@ module JMX
           end
         end
 
+        def find_local_url_by_pid(pid)
+          target_vmd = VirtualMachine.list.find do |vmd|
+            pid.to_s == vmd.id.to_s
+          end
+
+          if target_vmd
+            local_connector_address(target_vmd)
+          end
+        end
+
       private
 
         def local_connector_address(vm_descriptor)

--- a/lib/jmx4r.rb
+++ b/lib/jmx4r.rb
@@ -163,6 +163,9 @@ module JMX
     #                     if the command is specified, the host & port or the url
     #                     parameters are not taken into account
     #
+    # [:pid]              Connect to a local VM by pid (process id).  Works
+    #                     similarly to the :command options.
+    #
     # [:username]         the name of the user (if the MBean server requires authentication).
     #                     No default
     #
@@ -183,23 +186,26 @@ module JMX
       password = args[:password]
       credentials = args[:credentials]
       provider_package = args[:provider_package]
-      
+
       if args[:command]
         url = JDKHelper.find_local_url(args[:command]) or
           raise "no locally attacheable VMs"
+      elsif args[:pid]
+        url = JDKHelper.find_local_url_by_pid(args[:pid]) or
+          raise "no attachable VM with pid #{args[:pid]}"
       else
         # host & port are not taken into account if url is set (see issue #7)
         standard_url = "service:jmx:rmi:///jndi/rmi://#{host}:#{port}/jmxrmi"
         url = args[:url] || standard_url
       end
-      
+
       unless credentials
         if !username.nil? and username.length > 0
           user_password_credentials = [username, password]
           credentials = user_password_credentials.to_java(:String)
         end
       end
-      
+
       env = HashMap.new
       env.put(JMXConnector::CREDENTIALS, credentials) if credentials
       # only fill the Context and JMXConnectorFactory properties if provider_package is set

--- a/test/tc_connection.rb
+++ b/test/tc_connection.rb
@@ -88,4 +88,14 @@ class TestConnection < Test::Unit::TestCase
     end
   end
 
+  def test_establish_connection_local_with_pid
+    begin
+      pid = JConsole::start
+      connection = JMX::MBean.establish_connection :pid => pid
+      assert(connection.getMBeanCount > 0)
+    ensure
+      JConsole::stop
+    end
+  end
+
 end

--- a/test/tc_dynamic_mbean.rb
+++ b/test/tc_dynamic_mbean.rb
@@ -21,6 +21,9 @@ class TestDynamicMBean < Test::Unit::TestCase
     rw_attribute :map_attr, :map, "a Map attribute"
     rw_attribute :set_attr, :set, "a Set attribute"
     rw_attribute :boolean_attr, :boolean, "a Boolean attribute"
+
+    r_attribute :method_backed_attr, :string, 'Method backed attribute'
+    def method_backed_attr ; 'Not an instance variable' ; end
   end
 
   def test_attribute_types
@@ -59,6 +62,9 @@ class TestDynamicMBean < Test::Unit::TestCase
 
     mbean.boolean_attr = true
     assert_equal(true, mbean.boolean_attr)
+
+    # assers that overridden attr_reader is used
+    assert_equal "Not an instance variable", mbean.method_backed_attr
 
     mbean_server.unregister_mbean object_name
   end


### PR DESCRIPTION
Hey there,

So I've tweaked the dynamic mbean class a bit so that you can do things like:

```
class HttpServerMBean < JMX::DynamicMBean

  def initialize(http_server)
    @http_server = http_server
  end

  r_attribute :thread_count, :int, 'number of threads'

  def thread_count
    @http_server.thread_count
  end
end
```

It didn't work as it was, because it was fetching values by accessing the instance variable directly, which didn't seem necessary.  I could have gone a lot further, you can see the code above code benefit from some ruby meta magic, but this was just enough to get in what I needed.  I also made another small change so you can connect via pid, useful when you have a pidfile somewhere, as I often do.

Cheers,
Nick
